### PR TITLE
Add Renovate config and PR CI workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,49 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend (Go)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race ./...
+
+  frontend:
+    name: Frontend (Flutter)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "14 days",
+  "packageRules": [
+    {
+      "description": "Auto-merge minor, patch, pin, and digest updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true
+  }
+}


### PR DESCRIPTION
## Summary
- Renovate を導入し、minor/patch/pin/digest の自動マージを設定
- サプライチェーン攻撃緩和のため `minimumReleaseAge: 14 days` を採用 (脆弱性アラートも同じく 14 日待ち)
- PR 用 CI ワークフロー (Go build/test + Flutter analyze) を追加し、auto-merge の判定基準を確立

## 関連
- CVE-2026-42945 (NGINX Rift) 対応 (5c9edc5 → e409a76) を起点としたサプライチェーン対策強化
- 14日待ちにより既知 CVE の取り込みも 14 日遅延する点はトレードオフとして許容

## Test plan
- [ ] この PR で `Backend (Go)` ジョブが通過することを確認
- [ ] この PR で `Frontend (Flutter)` ジョブが通過することを確認
- [ ] マージ後、Renovate App が初回 Onboarding PR を作成することを確認
- [ ] Onboarding PR マージ後、依存更新 PR が CI 通過時に自動マージされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)