### PR TITLE
Tune Renovate config: docker exclusion, action digest pinning, flow control

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard"
+    "config:recommended"
   ],
   "timezone": "Asia/Tokyo",
   "labels": ["dependencies"],
   "minimumReleaseAge": "14 days",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
   "packageRules": [
     {
       "description": "Auto-merge minor, patch, pin, and digest updates",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "description": "Docker base images: skip auto-merge (PR CI does not exercise the built image)",
+      "matchManagers": ["dockerfile"],
+      "automerge": false,
+      "addLabels": ["docker-base-image"]
+    },
+    {
+      "description": "Group GitHub Actions updates and pin to commit SHA for supply chain hardening",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "pinDigests": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- Docker base image 更新を auto-merge から除外 (PR CI が built image を検証しないため)
- GitHub Actions の commit SHA pin (`pinDigests: true`) でタグ改竄攻撃を緩和
- GitHub Actions 更新を 1 PR にグループ化してノイズ削減
- `prHourlyLimit: 4` / `prConcurrentLimit: 10` で PR 流量を制御
- 冗長な `:dependencyDashboard` を削除 (`config:recommended` に内包済み)

## 背景
- 初回起動時に 15 件の更新 PR が一気に流れ、auto-merge は機能したものの GitHub Actions 系の PR が散発した
- nginx (CVE-2026-42945) を auto-merge できる体制は確立したが、Docker 系は CI で実動作確認できない以上、人間レビューを挟むべき
- サプライチェーン対策として action 参照を commit SHA に固定

## Test plan
- [ ] PR が両 CI (Backend (Go) / Frontend (Flutter)) を通過することを確認
- [ ] マージ後、次回 Renovate スキャンで Actions の grouped PR が `pinDigests` 適用された形で生成されることを確認
- [ ] Dockerfile 更新 PR が `docker-base-image` ラベル付きかつ auto-merge OFF で起票されることを確認 (今後の Docker 更新時に検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)