### PR TITLE
fix: nginx を 1.30.2-alpine に更新して CVE-2026-9256 / CVE-2026-42945 に対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
     go build -ldflags="-s -w" -trimpath -o server cmd/porker2/main.go
 
 # ===== Final Stage =====
-FROM nginx:1.30.1-alpine AS final
+FROM nginx:1.30.2-alpine AS final
 
 WORKDIR /app
 


### PR DESCRIPTION
ngx_http_rewrite_module のヒープバッファオーバーフロー (CVE-2026-42945, NGINX Rift) および未修正のメモリプール攻撃面 (CVE-2026-9256, nginx-poolslip) に対応するため、ベースイメージを 1.30.1 から修正版 1.30.2 に更新。

nginx.conf には脆弱性の起因となる rewrite ディレクティブは無く、設定変更は不要。 新イメージで nginx -t による構文チェック成功を確認済み。