### PR TITLE
ci: add on-merge-main and release workflows

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -1,0 +1,100 @@
+name: On Merge Main
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  DOCKER_IMAGE: swallowarc/porker2
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  backend:
+    name: Backend (Go)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race ./...
+
+  frontend:
+    name: Frontend (Flutter)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [backend, frontend]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        env:
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:latest
+            ${{ env.DOCKER_IMAGE }}:${{ steps.sha.outputs.short }}
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+
+env:
+  DOCKER_IMAGE: swallowarc/porker2
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Wait for On Merge Main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID=$(gh run list \
+            --workflow=on-merge-main.yml \
+            --commit="$GITHUB_SHA" \
+            --json databaseId,status \
+            --jq '[.[] | select(.status != "completed")] | .[0].databaseId // empty')
+          if [ -n "$RUN_ID" ]; then
+            echo "Waiting for On Merge Main (run $RUN_ID) to complete..."
+            gh run watch "$RUN_ID" --exit-status --interval 30
+          fi
+
+      - name: Release tag
+        id: tag
+        run: echo "name=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Tag container images
+        env:
+          SHA_TAG: ${{ steps.sha.outputs.short }}
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          docker pull "${{ env.DOCKER_IMAGE }}:${SHA_TAG}"
+          docker tag "${{ env.DOCKER_IMAGE }}:${SHA_TAG}" "${{ env.DOCKER_IMAGE }}:${RELEASE_TAG}"
+          docker push "${{ env.DOCKER_IMAGE }}:${RELEASE_TAG}"
+
+      - name: Create and push git tag
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          git tag "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: Release ${{ steps.tag.outputs.name }}
+          draft: false
+          prerelease: false
+          body: |
+            ## Docker Image
+
+            `${{ env.DOCKER_IMAGE }}:${{ steps.tag.outputs.name }}`
+
+            マルチアーキテクチャサポート: `linux/amd64`, `linux/arm64`
+
+            ### 使用方法
+
+            ```bash
+            docker run -d \
+              --name porker2 \
+              -p 8081:8081 \
+              -p 8082:8082 \
+              -e ENV=production \
+              -e REDIS_HOST_PORT=redis:6379 \
+              -e REDIS_DB=0 \
+              -e CONNECT_CORS_ALLOW_ORIGINS=http://localhost \
+              -e SESSION_COOKIE_DOMAIN=localhost \
+              ${{ env.DOCKER_IMAGE }}:${{ steps.tag.outputs.name }}
+            ```
+
+            ### 環境変数
+
+            | 変数名 | 説明 | デフォルト値 |
+            |--------|------|------------|
+            | `ENV` | 環境 (local/production) | local |
+            | `REDIS_HOST_PORT` | Redisホスト:ポート | localhost:6379 |
+            | `REDIS_DB` | Redis DBインデックス | 0 |
+            | `CONNECT_PORT` | バックエンドポート | 8080 |
+            | `CONNECT_CORS_ALLOW_ORIGINS` | CORS許可オリジン | 必須 |
+            | `SESSION_COOKIE_DOMAIN` | クッキードメイン | localhost |
+
+            詳細は [README.md](https://github.com/${{ github.repository }}) を参照してください。


### PR DESCRIPTION
autopostd と同様のリリース構成を porker2 に導入します。

### 変更内容

- `.github/workflows/on-merge-main.yml` を新規追加
  - main ブランチへの push で走る
  - PR 時は backend / frontend のチェックのみ実行
  - main push 時はチェック完了後に Docker イメージを `latest` と short SHA タグで push
- `.github/workflows/release.yml` を新規追加
  - `workflow_dispatch` のみで実行
  - 同一 commit の `on-merge-main` 完了を待機
  - `YYYYMMDDhhmmss` 形式のリリースタグを生成
  - short SHA の Docker イメージをリリースタグに retag して push
  - git タグを push して GitHub Release を作成

### 注意点

- 既存の `docker-build.yml` は、しばらく使っていたものですが、今回の構成と重複するため削除してもよいかもしれません。この PR では古いファイルを削除せず、パイロット導入としています。
- デプロイ時には `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN` が必要です。
