### PR TITLE
fix(fe): poker screen UI improvements (title centering, leave button, mobile card overlap)

### DIFF
--- a/frontend/lib/presentation/widget/app_bar.dart
+++ b/frontend/lib/presentation/widget/app_bar.dart
@@ -31,6 +31,27 @@ class Porker2AppBar extends HookConsumerWidget implements PreferredSizeWidget {
     final bool isMediumScreen =
         MediaQuery.of(context).size.width < mediumScreenBoundary;
 
+    if (onLeave != null) {
+      final errorColor = Theme.of(context).colorScheme.error;
+      actions.add(
+        isMediumScreen
+            ? IconButton(
+                onPressed: onLeave,
+                icon: Icon(Icons.exit_to_app, color: errorColor),
+                tooltip: 'Leave room',
+              )
+            : Padding(
+                padding: const EdgeInsets.only(right: 4),
+                child: TextButton.icon(
+                  onPressed: onLeave,
+                  icon: const Icon(Icons.exit_to_app),
+                  label: const Text('Leave'),
+                  style: TextButton.styleFrom(foregroundColor: errorColor),
+                ),
+              ),
+      );
+    }
+
     if (enableLogout) {
       final user = ref.read(userProvider.notifier);
       final userName = ref.watch(userProvider).userName;
@@ -101,25 +122,11 @@ class Porker2AppBar extends HookConsumerWidget implements PreferredSizeWidget {
         : txt;
 
     return AppBar(
-      title: Row(
-        children: [
-          if (onLeave != null)
-            Padding(
-              padding: const EdgeInsets.only(right: 12),
-              child: TextButton.icon(
-                onPressed: onLeave,
-                icon: const Icon(Icons.exit_to_app),
-                label: const Text('Leave'),
-              ),
-            ),
-          Flexible(
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: titleContent,
-            ),
-          ),
-        ],
+      title: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: titleContent,
       ),
+      centerTitle: true,
       actions: actions,
       automaticallyImplyLeading: false,
       leading: enableDrawer && isMediumScreen

--- a/frontend/lib/presentation/widget/poker/hand_cards.dart
+++ b/frontend/lib/presentation/widget/poker/hand_cards.dart
@@ -125,22 +125,31 @@ class HandCards extends HookConsumerWidget {
   Widget _scrollLayout(HandCard Function(Point, int) buildCard) {
     final allPoints = [...pointOrder, ..._extraPoints];
 
+    // BaseCard の SizedBox(width: 100) と揃える。
+    const cardWidth = 100.0;
+    // 72 未満にすると "0.5" などの中央ラベルが右隣のカードに隠れる。
+    const cardStep = 72.0;
+    final stripWidth = cardWidth + (allPoints.length - 1) * cardStep;
+
     return SizedBox(
       height: 180,
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            for (var i = 0; i < allPoints.length; i++) ...[
-              if (i > 0) const SizedBox(width: 12),
-              Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: buildCard(allPoints[i], i * 100),
-              ),
+        child: SizedBox(
+          width: stripWidth,
+          height: 180,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              for (var i = 0; i < allPoints.length; i++)
+                Positioned(
+                  left: i * cardStep,
+                  bottom: 10,
+                  child: buildCard(allPoints[i], i * 100),
+                ),
             ],
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary

- **Room ID タイトルの中央寄せ**: Leave ボタンが `AppBar.title` の `Row` に同居して左に押し出されていた退行（246a997 起因）を修正。`centerTitle: true` を明示。
- **Leave ボタンの移動**: 右上の actions 先頭へ移動し、`colorScheme.error` の destructive 色で表示。ワイド画面はラベル付き、モバイルはアイコン+ツールチップ。
- **モバイルの手札カードを重ね表示**: スクロールレイアウトを Row+12px 間隔から Stack の重ね配置（1枚あたり 112px → 72px）に変更し、横スクロール量を約1/3削減。重なり部分のタップは常に手前のカードに当たる。PC のファン表示は変更なし。

## Test plan

- [x] `flutter analyze` — 指摘なし
- [x] `flutter build web --release` — 成功
- [ ] 実機/ブラウザでモバイル幅の重なり量（`cardStep = 72.0`）の見た目確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)