### PR TITLE
ci: cross-compile in Docker build to cut multi-arch build time (~18min -> ~5min)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,7 +34,6 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request' || github.event.inputs.push == 'true'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -58,17 +57,11 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || github.event.inputs.push == 'true' }}
+          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event.inputs.push == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha
-            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
-          cache-to: |
-            type=gha,mode=max
-            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
 
   release:
     needs: build-and-push

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -51,11 +51,5 @@ jobs:
           tags: |
             ${{ env.DOCKER_IMAGE }}:latest
             ${{ env.DOCKER_IMAGE }}:${{ steps.sha.outputs.short }}
-          cache-from: |
-            type=gha
-            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
-          cache-to: |
-            type=gha,mode=max
-            type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.DOCKER_IMAGE }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # ===== Flutter Dependencies Stage =====
 # Cache Flutter dependencies separately to avoid re-downloading on code changes
-FROM swallowarc/flutter-builder AS flutter_deps
+# Web assets are architecture-independent: build once on the native build
+# platform instead of once per target platform under QEMU
+FROM --platform=$BUILDPLATFORM swallowarc/flutter-builder AS flutter_deps
 
 WORKDIR /app
 
@@ -21,7 +23,8 @@ RUN flutter build web --release --no-pub
 
 # ===== Go Dependencies Stage =====
 # Cache Go modules separately
-FROM golang:1.26-alpine AS go_deps
+# Runs on the native build platform; the target binary is cross-compiled
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS go_deps
 
 WORKDIR /app
 
@@ -41,10 +44,12 @@ WORKDIR /app
 COPY backend/ ./
 
 # Build with optimizations
-# - CGO_ENABLED=0 for static binary
+# - CGO_ENABLED=0 for static binary (also what makes cross-compilation safe)
+# - GOOS/GOARCH from BuildKit so each target platform gets a native binary
 # - ldflags -s -w to strip debug info and reduce binary size
 # - trimpath to remove file system paths from binary
-RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w" -trimpath -o server cmd/porker2/main.go
 
 # ===== Final Stage =====


### PR DESCRIPTION
## Summary

main マージ時の docker-build ジョブ約18分の内訳を実測したところ、ほぼ全てが arm64 向けステージの QEMU エミュレーション実行でした（`flutter build web` 802s、`go build` 659s）。さらに `GOARCH=amd64` がハードコードされており、公開中の arm64 イメージには amd64 バイナリが入っていて起動できない状態でした。

- **Dockerfile**: flutter/go のビルドステージを `--platform=$BUILDPLATFORM` に固定。Web アセットはアーキ非依存なので1回だけビルドし、Go は `TARGETOS`/`TARGETARCH` でクロスコンパイル（**arm64 バイナリのバグ修正を兼ねる**）。QEMU が必要なのは最終ステージ（nginx arm64）の `apk add`/`adduser` のみ。
- **キャッシュ二重化の解消**: `cache-to` の `type=gha,mode=max` を削除し registry buildcache に一本化（タグリリース側と共有）。明示的な `cache-to` 使用時に無意味な `BUILDKIT_INLINE_CACHE=1` も削除。
- **docker-build.yml の push 条件バグ修正**: `workflow_dispatch` の `push` 入力（デフォルト false）が `event_name != 'pull_request'`（常に真）に食われて必ず push されていた。タグ ref または `push=true` のときのみ push するよう修正。ログインは registry キャッシュ書き出しに必要なため無条件化。

## Test plan

- [x] ローカルで `--platform linux/arm64 --target build_backend` をビルドし、`file` で `ELF ARM aarch64, statically linked` を確認（QEMU 不使用で生成できることも確認）
- [x] ローカルで amd64 のイメージ全体ビルドが成功
- [ ] このブランチで `docker-build.yml` を `workflow_dispatch`（push=false）実行し、multi-arch ビルドの成功と所要時間を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)